### PR TITLE
Exclude vendor related files from VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+composer.phar


### PR DESCRIPTION
Even if it is often done globally, it is always useful IMO.