### PR TITLE
Fixed prepend extension to correctly load 'encryption' section

### DIFF
--- a/DependencyInjection/SpomkyLabsLexikJoseExtension.php
+++ b/DependencyInjection/SpomkyLabsLexikJoseExtension.php
@@ -92,7 +92,7 @@ final class SpomkyLabsLexikJoseExtension extends Extension implements PrependExt
         ConfigurationHelper::addHeaderChecker($container, $this->getAlias().'_signature', ['lexik_jose_signature_algorithm']);
         ConfigurationHelper::addKeyset($container, 'lexik_jose_bridge.signature', 'jwkset', ['value' => $bridgeConfig['key_set'], 'is_public' => $isDebug]);
 
-        if (isset($bridgeConfig['encryption']['enabled']) && (true == $bridgeConfig['encryption']['enabled'])) {
+        if (isset($bridgeConfig['encryption']['enabled']) && (true === $bridgeConfig['encryption']['enabled'])) {
             $this->enableEncryptionSupport($container, $bridgeConfig, $isDebug);
         }
 

--- a/DependencyInjection/SpomkyLabsLexikJoseExtension.php
+++ b/DependencyInjection/SpomkyLabsLexikJoseExtension.php
@@ -92,7 +92,7 @@ final class SpomkyLabsLexikJoseExtension extends Extension implements PrependExt
         ConfigurationHelper::addHeaderChecker($container, $this->getAlias().'_signature', ['lexik_jose_signature_algorithm']);
         ConfigurationHelper::addKeyset($container, 'lexik_jose_bridge.signature', 'jwkset', ['value' => $bridgeConfig['key_set'], 'is_public' => $isDebug]);
 
-        if (true === $bridgeConfig['encryption']['enabled']) {
+        if (isset($bridgeConfig['encryption']['enabled']) && (true == $bridgeConfig['encryption']['enabled'])) {
             $this->enableEncryptionSupport($container, $bridgeConfig, $isDebug);
         }
 


### PR DESCRIPTION
This conf 

```
lexik_jose:
    ttl: 1000
    server_name: '%env(SL_JOSE_BRIDGE_SERVER_NAME)%'
    key_set: '%env(file:SL_JOSE_BRIDGE_ALL_KEYS_PATH)%'
    key_index: 0
    signature_algorithm: 'RS256'
```
generated this error
```
Notice: Undefined index: encryption
In SpomkyLabsLexikJoseExtension.php line 95
```

I've changed the condition to check if the key `encryption` is set.