### PR TITLE
Correctly check existence of audience key | Related to #39

### DIFF
--- a/DependencyInjection/SpomkyLabsLexikJoseExtension.php
+++ b/DependencyInjection/SpomkyLabsLexikJoseExtension.php
@@ -41,7 +41,7 @@ final class SpomkyLabsLexikJoseExtension extends Extension implements PrependExt
         $container->setParameter('lexik_jose_bridge.encoder.signature_algorithm', $config['signature_algorithm']);
         $container->setParameter('lexik_jose_bridge.encoder.issuer', $config['server_name']);
 
-        if (null === $config['audience']) {
+        if (!isset($config['audience'])) {
             $config['audience'] = $config['server_name'];
         }
 


### PR DESCRIPTION
Check `null` was wrong