### PR TITLE
Mandatory claims

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -59,6 +59,14 @@ final class Configuration implements ConfigurationInterface
                     ->treatNullLike([])
                     ->treatFalseLike([])
                 ->end()
+                ->arrayNode('mandatory_claims')
+                    ->info('List of claims that must be present.')
+                    ->useAttributeAsKey('name')
+                    ->prototype('scalar')->end()
+                    ->defaultValue([])
+                    ->treatNullLike([])
+                    ->treatFalseLike([])
+                ->end()
             ->end();
 
         $this->addEncryptionSection($rootNode);

--- a/DependencyInjection/SpomkyLabsLexikJoseExtension.php
+++ b/DependencyInjection/SpomkyLabsLexikJoseExtension.php
@@ -47,6 +47,7 @@ final class SpomkyLabsLexikJoseExtension extends Extension implements PrependExt
         $container->setParameter('lexik_jose_bridge.encoder.audience', $config['audience']);
         $container->setParameter('lexik_jose_bridge.encoder.ttl', $config['ttl']);
         $container->setParameter('lexik_jose_bridge.encoder.claim_checked', $config['claim_checked']);
+        $container->setParameter('lexik_jose_bridge.encoder.mandatory_claims', $config['mandatory_claims']);
 
         $container->setParameter('lexik_jose_bridge.encoder.encryption.enabled', $config['encryption']['enabled']);
         if (true === $config['encryption']['enabled']) {

--- a/DependencyInjection/SpomkyLabsLexikJoseExtension.php
+++ b/DependencyInjection/SpomkyLabsLexikJoseExtension.php
@@ -37,14 +37,13 @@ final class SpomkyLabsLexikJoseExtension extends Extension implements PrependExt
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('lexik_jose_bridge.encoder.key_index', $config['key_index']);
-        $container->setParameter('lexik_jose_bridge.encoder.signature_algorithm', $config['signature_algorithm']);
-        $container->setParameter('lexik_jose_bridge.encoder.issuer', $config['server_name']);
-
         if (!isset($config['audience'])) {
             $config['audience'] = $config['server_name'];
         }
 
+        $container->setParameter('lexik_jose_bridge.encoder.key_index', $config['key_index']);
+        $container->setParameter('lexik_jose_bridge.encoder.signature_algorithm', $config['signature_algorithm']);
+        $container->setParameter('lexik_jose_bridge.encoder.issuer', $config['server_name']);
         $container->setParameter('lexik_jose_bridge.encoder.audience', $config['audience']);
         $container->setParameter('lexik_jose_bridge.encoder.ttl', $config['ttl']);
         $container->setParameter('lexik_jose_bridge.encoder.claim_checked', $config['claim_checked']);

--- a/Encoder/LexikJoseEncoder.php
+++ b/Encoder/LexikJoseEncoder.php
@@ -121,6 +121,11 @@ final class LexikJoseEncoder implements JWTEncoderInterface
     private $ttl;
 
     /**
+     * @var array
+     */
+    private $mandatoryClaims;
+
+    /**
      * LexikJoseEncoder constructor.
      *
      * @param JWSBuilder           $jwsBuilder
@@ -132,6 +137,7 @@ final class LexikJoseEncoder implements JWTEncoderInterface
      * @param string               $signatureAlgorithm
      * @param string               $issuer
      * @param int                  $ttl
+     * @param array                $mandatoryClaims
      */
     public function __construct(JWSBuilder $jwsBuilder,
                                 JWSVerifier $jwsLoader,
@@ -142,7 +148,8 @@ final class LexikJoseEncoder implements JWTEncoderInterface
                                 string $signatureAlgorithm,
                                 string $issuer,
                                 string $audience,
-                                int $ttl
+                                int $ttl,
+                                array $mandatoryClaims = []
     ) {
         $this->jwsBuilder = $jwsBuilder;
         $this->jwsLoader = $jwsLoader;
@@ -154,6 +161,7 @@ final class LexikJoseEncoder implements JWTEncoderInterface
         $this->issuer = $issuer;
         $this->audience = $audience;
         $this->ttl = $ttl;
+        $this->mandatoryClaims = $mandatoryClaims;
     }
 
     /**
@@ -285,7 +293,7 @@ final class LexikJoseEncoder implements JWTEncoderInterface
             throw new JWTDecodeFailureException('decoding_error', 'An error occurred while trying to verify the JWT token.');
         }
         $payload = $jsonConverter->decode($jws->getPayload());
-        $this->claimCheckerManager->check($payload);
+        $this->claimCheckerManager->check($payload, $this->mandatoryClaims);
 
         return $payload;
     }

--- a/Features/jwt_missing_claims.feature
+++ b/Features/jwt_missing_claims.feature
@@ -1,0 +1,48 @@
+Feature: The firewall must be able to detect bad tokens
+  The tokens may be missing claims
+  The firewall MUST reject all request with a bad token
+
+  Scenario: The token is missing the Expiration Time claim
+    Given I have a signed and encrypted token but without the "exp" claim
+    Given I add the token in the authorization header
+    When I am on the page "https://www.example.test/api/hello"
+    Then the response status code should be 401
+    And print last response
+    And the response should contain "Invalid JWT Token"
+    And the error listener should receive an invalid token event
+
+  Scenario: The token is missing the Issued At claim
+    Given I have a signed and encrypted token but without the "iat" claim
+    Given I add the token in the authorization header
+    When I am on the page "https://www.example.test/api/hello"
+    Then the response status code should be 401
+    And print last response
+    And the response should contain "Invalid JWT Token"
+    And the error listener should receive an invalid token event
+
+  Scenario: The token is missing the JWT ID claim
+    Given I have a signed and encrypted token but without the "jti" claim
+    Given I add the token in the authorization header
+    When I am on the page "https://www.example.test/api/hello"
+    Then the response status code should be 401
+    And print last response
+    And the response should contain "Invalid JWT Token"
+    And the error listener should receive an invalid token event
+
+  Scenario: The token is missing the Issuer claim
+    Given I have a signed and encrypted token but without the "iss" claim
+    Given I add the token in the authorization header
+    When I am on the page "https://www.example.test/api/hello"
+    Then the response status code should be 401
+    And print last response
+    And the response should contain "Invalid JWT Token"
+    And the error listener should receive an invalid token event
+
+  Scenario: The token is missing the Audience claim
+    Given I have a signed and encrypted token but without the "aud" claim
+    Given I add the token in the authorization header
+    When I am on the page "https://www.example.test/api/hello"
+    Then the response status code should be 401
+    And print last response
+    And the response should contain "Invalid JWT Token"
+    And the error listener should receive an invalid token event

--- a/Features/jwt_missing_claims.feature
+++ b/Features/jwt_missing_claims.feature
@@ -9,7 +9,7 @@ Feature: The firewall must be able to detect bad tokens
     Then the response status code should be 401
     And print last response
     And the response should contain "Invalid JWT Token"
-    And the error listener should receive an invalid token event
+    And the error listener should receive an invalid token event containing an exception with message "The following claims are mandatory: exp."
 
   Scenario: The token is missing the Issued At claim
     Given I have a signed and encrypted token but without the "iat" claim
@@ -18,7 +18,7 @@ Feature: The firewall must be able to detect bad tokens
     Then the response status code should be 401
     And print last response
     And the response should contain "Invalid JWT Token"
-    And the error listener should receive an invalid token event
+    And the error listener should receive an invalid token event containing an exception with message "The following claims are mandatory: iat."
 
   Scenario: The token is missing the JWT ID claim
     Given I have a signed and encrypted token but without the "jti" claim
@@ -27,7 +27,7 @@ Feature: The firewall must be able to detect bad tokens
     Then the response status code should be 401
     And print last response
     And the response should contain "Invalid JWT Token"
-    And the error listener should receive an invalid token event
+    And the error listener should receive an invalid token event containing an exception with message "The following claims are mandatory: jti."
 
   Scenario: The token is missing the Issuer claim
     Given I have a signed and encrypted token but without the "iss" claim
@@ -36,7 +36,7 @@ Feature: The firewall must be able to detect bad tokens
     Then the response status code should be 401
     And print last response
     And the response should contain "Invalid JWT Token"
-    And the error listener should receive an invalid token event
+    And the error listener should receive an invalid token event containing an exception with message "The following claims are mandatory: iss."
 
   Scenario: The token is missing the Audience claim
     Given I have a signed and encrypted token but without the "aud" claim
@@ -45,4 +45,4 @@ Feature: The firewall must be able to detect bad tokens
     Then the response status code should be 401
     And print last response
     And the response should contain "Invalid JWT Token"
-    And the error listener should receive an invalid token event
+    And the error listener should receive an invalid token event containing an exception with message "The following claims are mandatory: aud."

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -16,6 +16,7 @@ services:
             - '%lexik_jose_bridge.encoder.issuer%'
             - '%lexik_jose_bridge.encoder.audience%'
             - '%lexik_jose_bridge.encoder.ttl%'
+            - '%lexik_jose_bridge.encoder.mandatory_claims%'
 
     spomkylabs_lexik_jose_checker_audience:
         class: 'Jose\Component\Checker\AudienceChecker'

--- a/Resources/doc/Configuration.md
+++ b/Resources/doc/Configuration.md
@@ -17,7 +17,7 @@ lexik_jose:
     key_index: 0                                  // The index of the signature key in the key set
     signature_algorithm: "RS512"                  // The signature algorithm.
     claim_checked:                                // A list of additional claim checker aliases (optional).
-        - 'my_claim_checker_alias'                // See https://web-token.spomky-labs.com for more information
+        - 'my_claim_checker_alias'                // See https://web-token.spomky-labs.com/components/claim-checker for more information
 ```
 
 For all available signature algorithms and key sets, please refer to the [web-token/jwt-framework documentation](https://web-token.spomky-labs.com/).

--- a/Resources/doc/Configuration.md
+++ b/Resources/doc/Configuration.md
@@ -18,6 +18,11 @@ lexik_jose:
     signature_algorithm: "RS512"                  // The signature algorithm.
     claim_checked:                                // A list of additional claim checker aliases (optional).
         - 'my_claim_checker_alias'                // See https://web-token.spomky-labs.com/components/claim-checker for more information
+    mandatory_claims:                             // A list of claims that must be present (optional).
+        - 'exp'                                   // See https://web-token.spomky-labs.com/components/claim-checker for more information
+        - 'iat'
+        - 'iss'
+        - 'aud'
 ```
 
 For all available signature algorithms and key sets, please refer to the [web-token/jwt-framework documentation](https://web-token.spomky-labs.com/).

--- a/Tests/Context/LoginContext.php
+++ b/Tests/Context/LoginContext.php
@@ -296,6 +296,7 @@ trait LoginContext
             'jti'      => 'w53JxRXaEwGn80Jb4c-EZieTfvWgZDzhBw4C3Gv_0VId4zj4KaY6ujkDv9C3y7LLj5gSi9JCzfuBR2Km4vBsVA',
             'iss'      => $this->getContainer()->getParameter('lexik_jose_bridge.encoder.issuer'),
             'aud'      => $this->getContainer()->getParameter('lexik_jose_bridge.encoder.audience'),
+            'ip'       => '127.0.0.1'
         ];
     }
 

--- a/Tests/Context/RequestContext.php
+++ b/Tests/Context/RequestContext.php
@@ -211,4 +211,23 @@ trait RequestContext
             throw new \Exception();
         }
     }
+
+    /**
+     * @Then the error listener should receive an invalid token event containing an exception with message :message
+     */
+    public function theErrorListenerShouldReceiveAnInvalidTokenEventContainingAnExceptionWithMessage($message)
+    {
+        $events = $this->getContainer()->get('acme_api.event.jwt_created_listener')->getInvalidTokenEvents();
+
+        foreach ($events as $event) {
+            $exception = current($events)->getException();
+            do {
+                if ($exception->getMessage() === $message) {
+                    return;
+                }
+            } while ($exception = $exception->getPrevious());
+        }
+
+        throw new \Exception();
+    }
 }

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -37,6 +37,12 @@ lexik_jose:
     signature_algorithm: 'RS512' # The signature algorithm we want to use
     claim_checked:
         - 'lexik_jose_checker_claim_ip'
+    mandatory_claims:
+        - 'exp'
+        - 'iat'
+        - 'jti'
+        - 'iss'
+        - 'aud'
     encryption:
         enabled: true # We enable the encryption support
         key_set: '{"keys":[{"kid":"KEY_ID_0","kty":"oct","k":"z4nNE2pBccJDVs8Qnk7Znt1hTL3sqXz2kF3dsJqN_xE"},{"kid":"KEY_ID_1","kty":"oct","k":"sT3DyQXDIOwe6ADQtqusXAMyC-IaJZ2qqVvyK_d6P00"},{"kid":"KEY_ID_2","kty":"oct","k":"YLSnh2cw6qVtv1bRjOdHBS3fkF7e3HGbe04nBcuRflM"}]}'

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -24,6 +24,10 @@ twig:
     debug:            true
     strict_variables: true
 
+lexik_jwt_authentication:
+    secret_key: '%kernel.root_dir%/keys/private.key'
+    public_key: '%kernel.root_dir%/keys/public.key'
+
 lexik_jose:
     ttl: 1000
     server_name: 'https://my.super-service.org/'


### PR DESCRIPTION
The [Claim Checker component](https://web-token.spomky-labs.com/components/claim-checker) of JWT Framework supports mandatory claims. These can be passed as second argument of the method `Jose\Component\Checker\ClaimCheckerManager::check()`.

The bridge doesn't use that argument at all.

This PR introduces the configuration option `mandatory_claims`, passes its value to `SpomkyLabs\LexikJoseBundle\Encoder\LexikJoseEncoder`, which in turn passes it to `Jose\Component\Checker\ClaimCheckerManager::check()`.