### PR TITLE
Don't override "payload" with "additional payload" in the encoder

### DIFF
--- a/Encoder/LexikJoseEncoder.php
+++ b/Encoder/LexikJoseEncoder.php
@@ -217,10 +217,7 @@ final class LexikJoseEncoder implements JWTEncoderInterface
      */
     private function sign(array $payload): string
     {
-        $payload = array_merge(
-            $payload,
-            $this->getAdditionalPayload()
-        );
+        $payload += $this->getAdditionalPayload();
         $headers = $this->getSignatureHeader();
         $signatureKey = $this->signatureKeyset->get($this->signatureKeyIndex);
         if ($signatureKey->has('kid')) {


### PR DESCRIPTION
Don't override "payload" with "additional payload", but the other way around.

Use-case: I'm using a listener subscribed to the `JWT_CREATED` event to optionally add a custom `exp` value, in order to have a longer expiration time for certain users.

With the current behavior the custom `exp` value gets overridden when the token is signed. By having the "additional payload" act as defaults, I'm able to implement the behavior I want easily.