### PR TITLE
Enable reading the key set from a remote endpoint

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,12 @@ final class Configuration implements ConfigurationInterface
             throw new RuntimeException('Invalid root node');
         }
         $rootNode
+            ->validate()
+                ->ifTrue(static function(array $config): bool {
+                    return !isset($config['key_set']) && !isset($config['key_set_remote']);
+                })
+                ->thenInvalid('You must either configure a "key_set" or a "key_set_remote".')
+            ->end()
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('server_name')
@@ -47,7 +53,16 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('key_set')
                     ->info('Private/Shared keys used by this server to validate signed tokens. Must be a JWKSet object.')
-                    ->isRequired()
+                ->end()
+                ->arrayNode('key_set_remote')
+                    ->children()
+                        ->scalarNode('type')
+                            ->info('The type of the remote key set, either `jku` or `x5u`.')
+                        ->end()
+                        ->scalarNode('url')
+                            ->info('The URL from where the key set should be downloaded.')
+                        ->end()
+                    ->end()
                 ->end()
                 ->scalarNode('key_index')
                     ->info('Index of the key in the key set used to sign the tokens. Could be an integer or the key ID.')

--- a/DependencyInjection/SpomkyLabsLexikJoseExtension.php
+++ b/DependencyInjection/SpomkyLabsLexikJoseExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\LexikJoseBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use function array_key_exists;
 use Jose\Bundle\JoseFramework\Helper\ConfigurationHelper;
 use SpomkyLabs\LexikJoseBundle\Encoder\LexikJoseEncoder;
@@ -87,7 +88,12 @@ final class SpomkyLabsLexikJoseExtension extends Extension implements PrependExt
         ConfigurationHelper::addJWSVerifier($container, $this->getAlias(), [$bridgeConfig['signature_algorithm']], $isDebug);
         ConfigurationHelper::addClaimChecker($container, $this->getAlias(), $claim_aliases, $isDebug);
         ConfigurationHelper::addHeaderChecker($container, $this->getAlias().'_signature', ['lexik_jose_signature_algorithm']);
-        ConfigurationHelper::addKeyset($container, 'lexik_jose_bridge.signature', 'jwkset', ['value' => $bridgeConfig['key_set'], 'is_public' => $isDebug]);
+
+        if (isset($bridgeConfig['key_set_remote'])) {
+            ConfigurationHelper::addKeyset($container, 'lexik_jose_bridge.signature', $bridgeConfig['key_set_remote']['type'], ['url' => $bridgeConfig['key_set_remote']['url'], 'is_public' => $isDebug]);
+        } else if (isset($bridgeConfig['key_set'])) {
+            ConfigurationHelper::addKeyset($container, 'lexik_jose_bridge.signature', 'jwkset', ['value' => $bridgeConfig['key_set'], 'is_public' => $isDebug]);
+        }
 
         if (isset($bridgeConfig['encryption']['enabled']) && (true === $bridgeConfig['encryption']['enabled'])) {
             $this->enableEncryptionSupport($container, $bridgeConfig, $isDebug);

--- a/Resources/doc/Configuration.md
+++ b/Resources/doc/Configuration.md
@@ -3,7 +3,7 @@ How to configure this bundle?
 
 If you installed this bundle using Symfony Flex, it comes with a default configuration.
 **It is very important to change the key sets otherwise you will have a security issue.**
-**See the last section of this page to understand how to procced.**
+**See the last section of this page to understand how to proceed.**
 
 *Note: you can find [a complete example from our application configuration used for the tests](https://github.com/Spomky-Labs/lexik-jose-bridge/blob/v2.0/Tests/app/config/config.yml#L27-L41).*
 
@@ -18,15 +18,30 @@ lexik_jose:
     key_index: 0                                  // The index of the signature key in the key set
     signature_algorithm: "RS512"                  // The signature algorithm.
     claim_checked:                                // A list of additional claim checker aliases (optional).
-        - 'my_claim_checker_alias'                // See https://web-token.spomky-labs.com/components/claim-checker for more information
+        - 'my_claim_checker_alias'                // See https://web-token.spomky-labs.com/the-components/claim-checker for more information
     mandatory_claims:                             // A list of claims that must be present (optional).
-        - 'exp'                                   // See https://web-token.spomky-labs.com/components/claim-checker for more information
+        - 'exp'                                   // See https://web-token.spomky-labs.com/the-components/claim-checker for more information
         - 'iat'
         - 'iss'
         - 'aud'
 ```
 
 For all available signature algorithms and key sets, please refer to the [web-token/jwt-framework documentation](https://web-token.spomky-labs.com/).
+
+### With signature keys read from remote
+
+Use the `key_set_remote` instead of the `key_set` entry to read the signature keys from a remote endpoint. To get it
+working you need an HTTP client and a JKU factory configured. See
+[this documentation](https://web-token.spomky-labs.com/the-symfony-bundle/key-and-key-set-management/key-set-management-jwkset#distant-key-sets)
+to learn how to do it.
+
+```yml
+lexik_jose:
+    ...
+    key_set_remote:
+        type: 'jku'                               // The type of the remote key set, either `jku` or `x5u`
+        url: 'https://my.auth.server/jwks`        // The HTTPS url of the server providing the key set
+```
 
 ## With Encryption
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v3.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Thanks to this change it will be possible to use lexik-jose-bridge in scenarios where the keys are read from remote. Currently I would have to use the jwt-framework directly, and lose all the functionality that the LexikJWTAuthenticationBundle bundle gives.

This change enables the underlying jwt-framework to read the signature key set from a remote. Although this change in the configuration was necessary it's not enough to properly download the key set. I added a note in the docs pointing to the jwt-framework documentation which points what other configuration needs to be added.

I haven't added any tests. I'm not sure if this change is testable at all. If it is I would appreciate a hint on how to create the tests and I will add them here.


